### PR TITLE
Added AutoRepair

### DIFF
--- a/autoactions/actions/town/AutoRepair.cs
+++ b/autoactions/actions/town/AutoRepair.cs
@@ -1,0 +1,77 @@
+﻿namespace Turbo.plugins.patrick.autoactions.actions.town
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using parameters;
+    using Plugins;
+    using util.diablo;
+    using util.thud;
+
+    public class AutoRepair : AbstractAutoAction
+    {
+        public override string tooltip => "Will automatically repair at the blacksmith.";
+
+        public override string GetAttributes() => "";
+
+        public override long minimumExecutionDelta => 2000;
+
+        public override List<AbstractParameter> GetParameters()
+        {
+            return new List<AbstractParameter>();
+        }
+
+        public override bool Applicable(IController hud)
+        {
+            if (!hud.Game.Me.IsInTown || !hud.Render.IsUiElementVisible(UiPathConstants.Blacksmith.UNIQUE_PAGE))
+                return false;
+
+            if (!AnyDamagedItems(hud))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public override void Invoke(IController hud)
+        {
+            var goldCostElement = hud.Render.GetOrRegisterAndGetUiElement(UiPathConstants.Blacksmith.REPAIR_ALL);
+            hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Blacksmith.REPAIR_PAGE, 500);
+            var goldCost = GetGoldCost(goldCostElement);
+            if (goldCost > hud.Game.Me.Materials.Gold)
+            {
+                // We can't afford to repair, let's not try and end up in a repair loop.
+                return;
+            }
+
+            hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Blacksmith.REPAIR_ALL, 250);
+        }
+
+        private static long GetGoldCost(IUiElement repairAll)
+        {
+            var goldCostText = repairAll?.ReadText(System.Text.Encoding.ASCII, true);
+            var extractedGoldCost = GoldRegex.Match(goldCostText);
+            long.TryParse(extractedGoldCost.Value?.Trim(), out var goldCost);
+            return goldCost;
+        }
+
+        private static Regex GoldRegex = new Regex(@".(\d+).");
+
+        private bool AnyDamagedItems(IController hud)
+        {
+            var equippedItems = hud.Game.Items.Where(i => i.Location == ItemLocation.Head || i.Location == ItemLocation.Torso || i.Location == ItemLocation.Torso ||
+                i.Location == ItemLocation.RightHand || i.Location == ItemLocation.LeftHand || i.Location == ItemLocation.Hands || i.Location == ItemLocation.Waist ||
+                i.Location == ItemLocation.Feet || i.Location == ItemLocation.Shoulders || i.Location == ItemLocation.Legs || i.Location == ItemLocation.Bracers ||
+                i.Location == ItemLocation.LeftRing || i.Location == ItemLocation.RightRing || i.Location == ItemLocation.Neck);
+            foreach (var item in equippedItems)
+            {
+                var currentDurability = item.StatList.FirstOrDefault(i => i.Id.Contains("Durability_Cur"))?.DoubleValue;
+                var maxDurability = item.StatList.FirstOrDefault(i => i.Id.Contains("Durability_Max"))?.DoubleValue;
+                if (currentDurability != maxDurability)
+                    return true; // Return as soon as we find just one item damaged
+            }
+            return false;
+        }
+    }
+}

--- a/autoactions/actions/town/SalvageYBW.cs
+++ b/autoactions/actions/town/SalvageYBW.cs
@@ -1,11 +1,11 @@
 ﻿namespace Turbo.plugins.patrick.autoactions.actions.town
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
-    using parameters;
+    using System;
     using parameters.types;
+    using parameters;
     using Plugins;
     using util.diablo;
     using util.thud;
@@ -17,8 +17,6 @@
         public bool Blues { get; set; }
 
         public bool Whites { get; set; }
-
-        private bool hasSalvaged;
 
         public override string tooltip => "Automatically salvages Yellow/Blue/White items when visiting the blacksmith";
 
@@ -42,15 +40,13 @@
                 return false;
 
             var blacksmithOpen = hud.Render.IsUiElementVisible(UiPathConstants.Blacksmith.UNIQUE_PAGE);
-            if (!blacksmithOpen)
-                hasSalvaged = false;
 
             return blacksmithOpen;
         }
 
         public override void Invoke(IController hud)
         {
-            if (hasSalvaged)
+            if (!hud.Inventory.ItemsInInventory.ToList().Any(x => x.IsRare || x.IsMagic || x.IsNormal && x.SnoItem.Kind == ItemKind.loot))
                 return;
 
             hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Blacksmith.SALVAGE_PAGE, 500);
@@ -70,9 +66,7 @@
                 hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Blacksmith.SALVAGE_WHITE, 500);
                 hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Blacksmith.SALVAGE_DIALOG_OK, 500);
             }
-            
-            hasSalvaged = true;
-            
+
             hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Blacksmith.ANVIL);
         }
     }

--- a/util/diablo/UiPathConstants.cs
+++ b/util/diablo/UiPathConstants.cs
@@ -55,6 +55,9 @@
             public const string SALVAGE_RARE = "Root.NormalLayer.vendor_dialog_mainPage.salvage_dialog.salvage_all_wrapper.salvage_rare_button";
             public const string SALVAGE_BLUE = "Root.NormalLayer.vendor_dialog_mainPage.salvage_dialog.salvage_all_wrapper.salvage_magic_button";
             public const string SALVAGE_WHITE = "Root.NormalLayer.vendor_dialog_mainPage.salvage_dialog.salvage_all_wrapper.salvage_normal_button";
+
+            public const string REPAIR_PAGE = "Root.NormalLayer.vendor_dialog_mainPage.tab_3";
+            public const string REPAIR_ALL = "Root.NormalLayer.vendor_dialog_mainPage.repair_dialog.RepairAll";
         }
 
         public static class Ui


### PR DESCRIPTION
- Only tries to repair if there is damaged items.
- Only tries to repair if there is gold enough to pay for the repair.

Tested with both SalvageYWB & AutoRepair enabled and it does work, just a little slower for the repair when both enabled.