### PR TITLE
Automainstat: check for open dialogs

### DIFF
--- a/autoactions/actions/town/AutoMainstat.cs
+++ b/autoactions/actions/town/AutoMainstat.cs
@@ -28,7 +28,12 @@
 
         public override bool Applicable(IController hud)
         {
-            return hud.Game.IsInTown && hud.Render.IsUiElementVisible(UiPathConstants.Paragon.NEW_PARAGON_BUTTON);
+            return hud.Game.IsInTown 
+                && hud.Render.IsUiElementVisible(UiPathConstants.Paragon.NEW_PARAGON_BUTTON)
+                && !hud.Render.IsUiElementVisible(UiPathConstants.Dialogs.QUEST_COMPLETED) 
+                && !hud.Render.IsUiElementVisible(UiPathConstants.Dialogs.HORADRIC_CACHE)
+                && !hud.Render.IsUiElementVisible(UiPathConstants.Dialogs.GREATER_RIFT_COMPLETED) 
+                && !hud.Render.IsUiElementVisible(UiPathConstants.Dialogs.GREATER_RIFT_INVITE);
         }
 
         public override void Invoke(IController hud)

--- a/util/diablo/UiPathConstants.cs
+++ b/util/diablo/UiPathConstants.cs
@@ -41,6 +41,14 @@
             }
         }
 
+        public static class Dialogs
+        {
+            public const string QUEST_COMPLETED = "Root.NormalLayer.questreward_dialog";
+            public const string HORADRIC_CACHE = "Root.NormalLayer.BountyReward_main.LayoutRoot";
+            public const string GREATER_RIFT_COMPLETED = "Root.NormalLayer.GreaterRifts_VictoryScreen.LayoutRoot";
+            public const string GREATER_RIFT_INVITE = "Root.NormalLayer.rift_join_party_main.LayoutRoot";
+        }
+
         public static class Blacksmith
         {
             public const string UNIQUE_PAGE = "Root.NormalLayer.vendor_dialog_mainPage.tab_4";


### PR DESCRIPTION
Prevents automainstat trying to add paragon when there is a dialog open