### PR TITLE
Autoactions: bugfixes

### DIFF
--- a/autoactions/actions/general/AutoDialog.cs
+++ b/autoactions/actions/general/AutoDialog.cs
@@ -35,8 +35,8 @@ namespace Turbo.plugins.patrick.autoactions.actions.town
             if(hud.Render.IsUiElementVisible(UiPathConstants.Dialogs.QUEST_COMPLETED_CLOSE_BUTTON))
                 hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Dialogs.QUEST_COMPLETED_CLOSE_BUTTON);
 
-            if(hud.Render.IsUiElementVisible(UiPathConstants.Dialogs.CONVERSATION_CLOSE_BUTTON))
-                hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Dialogs.CONVERSATION_CLOSE_BUTTON);
+            if(hud.Render.IsUiElementVisible(UiPathConstants.Dialogs.HORADRIC_CACHE_CLOSE_BUTTON))
+                hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Dialogs.HORADRIC_CACHE_CLOSE_BUTTON);
         }
     }
 }

--- a/autoactions/actions/rift/AutoNextFloor.cs
+++ b/autoactions/actions/rift/AutoNextFloor.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System;
     using parameters;
     using parameters.types;
     using Plugins;
@@ -28,6 +29,7 @@
             return !hud.Game.Me.IsDead 
                 && (hud.Game.SpecialArea == SpecialArea.GreaterRift || hud.Game.SpecialArea == SpecialArea.Rift)
                 && closestPortal.CentralXyDistanceToMe <= 16 
+                && Char.IsDigit(portalTarget.Last())
                 && portalTarget.Last() > currentPosition.Last();
         }
 


### PR DESCRIPTION
Fixes a mistake in autodialog
Fixes autonextfloor seeing the town as the next floor since letters have a higher ascii value vs digits