### PR TITLE
Update AutoMainstat.cs

### DIFF
--- a/autoactions/actions/town/AutoMainstat.cs
+++ b/autoactions/actions/town/AutoMainstat.cs
@@ -46,6 +46,7 @@
             if (amountOfClicks == 0)
             {
                 hud.Render.WaitForVisiblityAndClickOrAbortHotkeyEvent(UiPathConstants.Paragon.PARAGON_BUTTON_CLOSE);
+                return;
             }
 
             InputSimulator.PostMessageKeyDown(Keys.ControlKey);


### PR DESCRIPTION
Fixes running south when entering game if there are no paragons to be assigned on 0 area damage builds